### PR TITLE
Feature/utility as derive

### DIFF
--- a/src/actions/deriveAddress.ts
+++ b/src/actions/deriveAddress.ts
@@ -3,41 +3,57 @@ import { u8aSorted } from "@polkadot/util";
 import { blake2AsU8a } from "@polkadot/util-crypto";
 
 type Options = {
-  addresses: string;  // CSV of the addresses.
+  address: string; // CSV of the addresses.
   ss58Prefix: string; // Prefix for the network encoding to use.
-  threshold: string;  // Number of addresses that are needed to approve an action.
-}
+  index: string; // Number of addresses that are needed to approve an action.
+};
 
-const derivePubkey = (addresses: string[], threshold = 1): Uint8Array => {
+const derivePubkey = (address: string, index = 0): Uint8Array => {
   const prefix = "modlpy/utilisuba";
-  const payload = new Uint8Array(prefix.length + 1 + 32 * addresses.length + 2);
+  const payload = new Uint8Array(prefix.length + 32 + 2);
   payload.set(
     Array.from(prefix).map((c) => c.charCodeAt(0)),
     0
   );
-  payload[prefix.length] = addresses.length << 2;
-  const pubkeys = addresses.map((addr) => decodeAddress(addr));
-  u8aSorted(pubkeys).forEach((pubkey, idx) => {
-    payload.set(pubkey, prefix.length + 1 + idx * 32);
-  });
-  payload[prefix.length + 1 + 32 * addresses.length] = threshold;
-
+  const pubkey = decodeAddress(address);
+  payload.set(pubkey, prefix.length);
+  // have to set the bytes manually, little endian encoding
+  const indexBytes = numberToByteArray(index);
+  payload[prefix.length + 32] = indexBytes[0];
+  payload[prefix.length + 33] = indexBytes[1];
   return blake2AsU8a(payload);
-}
+};
 
 export const deriveAddress = (opts: Options): void => {
-  const { addresses, ss58Prefix, threshold } = opts;
+  const { address, ss58Prefix, index } = opts;
 
-  if (!addresses) throw new Error("Please provide the addresses option.");
+  if (!address) {
+    throw new Error("Please provide the addresses option.");
+  }
+  if (Number(index) > 65535) {
+    throw new Error("Index cannot be greater than 2**16");
+  }
 
-  const addrs = addresses.split(",").filter((x) => !!x);
-
-  const pubkey = derivePubkey(addrs, Number(threshold));
+  const pubkey = derivePubkey(address, Number(index));
   const msig = encodeAddress(pubkey, Number(ss58Prefix));
 
   console.log("-".repeat(32));
-  console.log(`Addresses: ${addrs.join(" ")}`);
-  console.log(`Threshold: ${threshold}`);
+  console.log(`Address: ${address}`);
+  console.log(`index: ${index}`);
   console.log(`Multisig Address (SS58: ${ss58Prefix}): ${msig}`);
   console.log("-".repeat(32));
-}
+};
+
+// https://stackoverflow.com/a/12965194
+function numberToByteArray(number: number): Uint8Array {
+  // we want to represent the input as a 8-bytes array
+  const byteArray = new Uint8Array(2);
+
+  for (let index = 0; index < byteArray.length; index++) {
+    const byte = number & 0xff;
+    byteArray[index] = byte;
+    number = (number - byte) / 256;
+  }
+
+  return byteArray;
+};

--- a/src/actions/deriveAddress.ts
+++ b/src/actions/deriveAddress.ts
@@ -17,7 +17,7 @@ const derivePubkey = (address: string, index = 0): Uint8Array => {
   );
   const pubkey = decodeAddress(address);
   payload.set(pubkey, prefix.length);
-  // have to set the bytes manually, little endian encoding
+  // have to set the bytes manually, big endian encoding
   const indexBytes = numberToByteArray(index);
   payload[prefix.length + 32] = indexBytes[0];
   payload[prefix.length + 33] = indexBytes[1];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import { deriveAddress } from "./actions/deriveAddress";
 
 program
   .command("derive")
-  .option("--addresses <addr1,addr2,...>", "The addresses that compose the multisig (comma-separated).", "")
-  .option("--threshold <num>", "The threshold of approvals needed.", "0")
+  .option("--address <addr>", "The address that you're deriving from.", "")
+  .option("--index <num>", "The indesx of the derived account (default 0).", "0")
   .option("--ss58Prefix <num>", "The prefix for the network to use for encoding.", "0")
   .action(deriveAddress);
 


### PR DESCRIPTION
Using this tool it's possible to generate the derivative address at a particular index for an account. This implementation uses the code in the Utility Pallet as a reference:

```rust
impl<T: Config> Pallet<T> {
	/// Derive a derivative account ID from the owner account and the sub-account index.
	pub fn derivative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
		let entropy = (b"modlpy/utilisuba", who, index).using_encoded(blake2_256);
		Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
			.expect("infinite length input; no invalid inputs for type; qed")
	}
}
```

No need to merge this, just opening it for reference.